### PR TITLE
Hashmap additions

### DIFF
--- a/data_structures/hashmap/Hashmap.ts
+++ b/data_structures/hashmap/Hashmap.ts
@@ -206,7 +206,9 @@ export class Hashmap<T> {
     }
 
     private _hash_by_multiplication(digest: number, buckets: number): number {
-        return Math.floor(buckets * Math.trunc(digest * (this.#multiplication_factor as number)));
+        const prod = digest * (this.#multiplication_factor as number);
+        const frac = prod - ~~prod;
+        return Math.floor(buckets * frac);
     }
 
     /**
@@ -254,7 +256,6 @@ export class Hashmap<T> {
             }
 
             wanted_num_buckets = Math.ceil(this.elements / desired);
-            console.log("DESIRED IS",desired);
         } else {
             wanted_num_buckets = desired;
         }
@@ -306,7 +307,6 @@ export class Hashmap<T> {
             // This might happen when the hm is small
             // Namely, when 2E/B <== m+M < 2E/(B-1) where E is # elements, B is current # buckets, m is min LF, M is max LF
             if(new_buckets === current_num_buckets) {
-                console.log("Equals condition")
                 if(this.elements - 1 < (<[number, number]>this.valid_elements_range)[1]) {
                     this.rehash(current_num_buckets - 1, true);
                 }
@@ -410,7 +410,6 @@ export class Hashmap<T> {
             // This might happen when the hm is small
             // Namely, when 2E/B <== m+M < 2E/(B-1) where E is # elements, B is current # buckets, m is min LF, M is max LF
             if(new_buckets === current_num_buckets) {
-                console.log("Equals condition")
                 if(this.elements + 1 > (<[number, number]>this.valid_elements_range)[1]) {
                     this.rehash(current_num_buckets + 1, true);
                 }
@@ -452,8 +451,10 @@ export class Hashmap<T> {
         if(hashing_method === "MODULO") {
             if(typeof config.multiplication_factor !== "undefined") throw Error(HashmapErrors.MULTIPLICATION_FACTOR_PROVIDED_MODULO);
         } else {
-            if(typeof config.multiplication_factor !== "undefined") {
+            if(typeof config.multiplication_factor === "undefined") {
                 this.#multiplication_factor = 0.618;
+            } else {
+                this.#multiplication_factor = config.multiplication_factor;
             }
         }
 

--- a/data_structures/hashmap/Hashmap.ts
+++ b/data_structures/hashmap/Hashmap.ts
@@ -34,13 +34,45 @@ export function default_hash_function(key: Key): number {
     return hash;
 };
 
+/**
+ * The parameters with which to instantiate the hashmap.
+ * 
+ * Only `initial_values` and `initial_keys` are required.
+ */
 type HashmapConfig<T> =  {
+    /**
+     * An array of initial values for the hashmap. Must be the same length as `initial_keys`.
+     */
     initial_values: T[],
+    /**
+     * An array of initial keys for the hashmap. Must be the same length as `initial_values`.
+     */
     initial_keys: Key[],
+    /**
+     * The hash function to use. If not specified, uses {@link default_hash_function a default} equivalent to Java's `hashCode`.
+     */
     hash_function?: (key: string) => number,
+    /**
+     * Initial number of buckets to use.
+     * - If not specified when not using dynamic rehashing, uses `ceil(1.5 * initial_keys.length)`.
+     * - If not specified when using dynamic rehashing, uses `ceil(2 * initial_keys.length / (min_load_factor + max_load_factor))`; this means the load factor will be close to the average of `min_load_factor` and `max_load_factor`.
+     */
     buckets?: number,
+    /**
+     * Whether or not to enable dynamic rehashing. 
+     * When enabled, the hashmap will automatically scale in/out the number of buckets if the load factor falls outside the bounds provided by `min_load_factor`, `max_load_factor`. 
+     * `false` if not provided.
+     */
     enable_dynamic_rehashing?: boolean,
+    /**
+     * Minimum acceptable load factor. 
+     * If not provided when `enable_dynamic_rehashing` is `true`, defaults to `0.60`.
+     */
     min_load_factor?: number,
+    /**
+     * Maximum acceptable load factor. 
+     * If not provided when `enable_dynamic_rehashing` is `true`, defaults to `0.75`.
+     */
     max_load_factor?: number,
 };
 
@@ -373,28 +405,9 @@ export class Hashmap<T> {
 
         this.elements++;
     }
-    
+
     /**
-     * @constructor
-     * @param initial_values An array of initial values for the hashmap. 
-     * Must be the same length as `initial_keys`.
-     * @param initial_keys An array of initial keys for the hashmap. 
-     * Must be the same length as `initial_values`.
-     * @param [hash_function] The hash function to use. 
-     * If not specified, uses an {@link Hashmap._default_hash_function internal default} equivalent to Java's `hashCode` function.
-     * @param [buckets] The number of initial buckets. 
-     * If not specified when not using dynamic rehashing, uses `ceil(1.5 * initial_keys.length)`.
-     * If not specified when using dynamic rehashing, uses `ceil(2 * initial_keys.length / (min_load_factor + max_load_factor))`; this means the load factor will be close to the average of `min_load_factor` and `max_load_factor`.
-     * @param [enable_dynamic_rehashing] Whether or not to enable dynamic rehashing. 
-     * When enabled, the hashmap will automatically scale in/out the number of buckets if the load factor falls outside the bounds provided by `min_load_factor`, `max_load_factor`. 
-     * `false` if not provided.
-     * @param [min_load_factor] Minimum acceptable load factor. 
-     * If not provided when `enable_dynamic_rehashing` is `true`, defaults to `0.60`.
-     * Otherwise, defaults to `null`.
-     * @param [max_load_factor] Maximum acceptable load factor. 
-     * If not provided when `enable_dynamic_rehashing` is `true`, defaults to `0.75`.
-     * Otherwise, defaults to `null`.
-     * 
+     * @param config See {@link HashmapConfig}.
      */
     constructor(config: HashmapConfig<T>) {
         if(config.initial_values.length !== config.initial_keys.length) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-dsa",
   "description": "Collection of common data structures / algorithms implemented in TypeScript",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "devDependencies": {
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",

--- a/tests/Hashmap.test.ts
+++ b/tests/Hashmap.test.ts
@@ -108,4 +108,24 @@ describe("basic usage", () => {
         my_hashmap.insert(12, 30);
         my_hashmap.insert(10, 35);
     });
+
+    it("supports accessing w/ hash by multiplication", () => {
+        const my_hashmap = new Hashmap<number>({
+            initial_values: [1,2,3],
+            initial_keys: [4,5,6], 
+            hashing_method: "MULTIPLICATION"
+        });
+
+        expect(my_hashmap.access(4)).toBe(1);
+    });
+
+    it("supports removal w/ hash by multiplication", () => {
+        const my_hashmap = new Hashmap<number>({
+            initial_values: [1,2,3,4,5,6,7,8,9,10],
+            initial_keys: [4,5,6,10,2,11,12,13,14,15], 
+            hashing_method: "MULTIPLICATION"
+        });
+
+        expect(() => my_hashmap.delete(5)).not.toThrow(Error);
+    });
 });

--- a/tests/Hashmap.test.ts
+++ b/tests/Hashmap.test.ts
@@ -3,24 +3,36 @@ import { Hashmap, HashmapErrors } from "../data_structures/hashmap/Hashmap";
 describe("basic usage", () => {
     it("supports initialization", () => {
         expect(() => {
-            const my_hashmap = new Hashmap<number>([1,2,3], ["a", "b", "c"]);
+            const my_hashmap = new Hashmap<number>({
+                initial_values: [1,2,3],
+                initial_keys: ["a","b","c"]
+            })
         }).not.toThrow(Error);
     });
 
     it("does not support initialization w/ mismatched length of initial value & initial keys", () => {
         expect(() => {
-            const my_hashmap = new Hashmap<string>(["a","b"], ["z", "y", "x"]);
+            const my_hashmap = new Hashmap<string>({
+                initial_keys: ["a","b"],
+                initial_values: ["b","d","e"]
+            });
         }).toThrow(Error(HashmapErrors.INIT_ARRAY_LENGTH_MISMATCH));
     });
 
     it("supports accessing", () => {
-        const my_hashmap = new Hashmap<number>([1,2,3], ["jerry", "broxley", "jomble"]);
+        const my_hashmap = new Hashmap<number>({
+            initial_values: [1,2,3],
+            initial_keys: ["jerry", "broxley", "jomble"]
+        });
 
         expect(my_hashmap.access("jerry")).toEqual(1);
     });
 
     it("supports deletion", () => {
-        const my_hashmap = new Hashmap<number>([10,9,8], ["archibald", "jordan", "jerome"]);
+        const my_hashmap = new Hashmap<number>({
+            initial_values: [10,9,8],
+            initial_keys: ["archibald","jordan","jerome"]
+        });
         
         expect(my_hashmap.access("jordan")).toBe(9);
         expect(my_hashmap.access("archibald")).toBe(10);
@@ -32,14 +44,20 @@ describe("basic usage", () => {
     });
 
     it("has 0 load factor when empty", () => {
-        const my_hashmap = new Hashmap<number>([1], ["a"]);
+        const my_hashmap = new Hashmap<number>({
+            initial_keys: ["a"],
+            initial_values: [1]
+        });
 
         my_hashmap.delete("a");
         expect(my_hashmap.load_factor).toBe(0);
     });
 
     it("supports access w/ number-key", () => {
-        const my_hashmap = new Hashmap<string>(["jeremy", "davis", "paul"], [10,9,5]);
+        const my_hashmap = new Hashmap<string>({
+            initial_values: ["jeremy", "davis", "paul"],
+            initial_keys: [10,9,5]
+        })
 
         expect(my_hashmap.access(10)).toBe("jeremy");
         expect(my_hashmap.access(9)).toBe("davis");
@@ -47,14 +65,20 @@ describe("basic usage", () => {
     });
 
     it("supports deletion w/ number key", () => {
-        const my_hashmap = new Hashmap<{name: string}>([{name: "jerry"}, {name: "jack"}], [4,3]);
+        const my_hashmap = new Hashmap({
+            initial_values: [{name: "jerry"}, {name: "jack"}],
+            initial_keys: [4,3]
+        })
 
         my_hashmap.delete(4);
         expect(my_hashmap.elements).toBe(1);
     })
 
     it("supports insertion w/ number key", () => {
-        const my_hashmap = new Hashmap<string>(["jeremy", "davis", "paul"], [10,9,5]);
+        const my_hashmap = new Hashmap<string>({
+            initial_values: ["jeremy", "davis", "paul"],
+            initial_keys: [10,9,5]
+        })
 
         my_hashmap.insert("jackson", 11);
 
@@ -62,13 +86,23 @@ describe("basic usage", () => {
     });
 
     it("supports rehashing", () => {
-        const my_hashmap = new Hashmap<string>(["jeremy", "davis", "paul"], [10,9,5]);
+        const my_hashmap = new Hashmap<string>({
+            initial_values: ["jeremy", "davis", "paul"],
+            initial_keys: [10,9,5]
+        })
+
         my_hashmap.rehash(1);
         expect(my_hashmap.load_factor).toBe(1);
     });
 
     it("supports dynamic rehashing", () => {
-        const my_hashmap = new Hashmap<number>([1,2,3], [4,5,6],undefined,undefined,true,0.6,0.75);
+        const my_hashmap = new Hashmap<number>({
+            initial_values: [1,2,3], 
+            initial_keys: [4,5,6],
+            enable_dynamic_rehashing: true,
+            min_load_factor: 0.6,
+            max_load_factor: 0.75
+        });
         my_hashmap.insert(10, 3);
         my_hashmap.insert(15, 19);
         my_hashmap.insert(12, 30);

--- a/tests/Hashmap.test.ts
+++ b/tests/Hashmap.test.ts
@@ -128,4 +128,24 @@ describe("basic usage", () => {
 
         expect(() => my_hashmap.delete(5)).not.toThrow(Error);
     });
+
+    it("supports dynamic rehashing w/ hash by multplication", () => {
+        const my_hashmap = new Hashmap<number>({
+            initial_values: [1,2,3,4,5,6,7,8,9,10],
+            initial_keys: [4,5,6,10,2,11,12,13,14,15], 
+            hashing_method: "MULTIPLICATION",
+            enable_dynamic_rehashing: true,
+            min_load_factor: 0.4,
+            max_load_factor: 0.8
+        });
+
+        const before = my_hashmap.load_factor;
+
+        for(let i=100;i<200;i++) my_hashmap.insert(i, i);
+
+        const after = my_hashmap.load_factor;
+        console.log(before,after)
+
+        expect(after).not.toBe(before);
+    });
 });


### PR DESCRIPTION
- change hashmap constructor to take config object
- move documentation for hashmap config
- implement hashing by multiplication
- preliminary fixes
- couple more tests
- 1.1.0

This adds hashing by multiplication and changes Hashmap to use a config object as a constructor parameter rather than positional arguments.
